### PR TITLE
Support intra-site links to source content files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         id: check_release
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry githubrelease httpx==0.16.1 autopub
+          python -m pip install poetry githubrelease autopub httpx==0.16.1
           echo "##[set-output name=release;]$(autopub check)"
       - name: Publish
         if: ${{ steps.check_release.outputs.release=='' }}

--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ To customize the PDF output, you can use the following settings in your Pelican 
 `PDF_STYLE_PATH` defines a new path where *rst2pdf* will look for style sheets, while `PDF_STYLE` specifies the style you want to use.
 For a description of the available styles, please read the [rst2pdf documentation](http://rst2pdf.ralsina.me/handbook.html#styles).
 
-Known Issues
-------------
-
-Intra-site link syntax in the form of `{filename}images/test.png` is not yet handled by the PDF generator.
-
 Contributors
 ------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Support intra-site links to source content files

--- a/pelican/plugins/pdf/pdf.py
+++ b/pelican/plugins/pdf/pdf.py
@@ -53,15 +53,9 @@ class PdfGenerator(Generator):
         mdreader = MarkdownReader(self.settings)
         _, ext = os.path.splitext(obj.source_path)
 
-        hrefs = self._get_intrasite_link_regex()
-
         if ext == ".rst":
             with open(obj.source_path, encoding="utf-8") as f:
                 text = f.read()
-
-                text = hrefs.sub(
-                    lambda m: obj._link_replacer(obj.get_siteurl(), m), text
-                )
 
             header = ""
         elif ext[1:] in mdreader.file_extensions and mdreader.enabled:
@@ -83,8 +77,6 @@ class PdfGenerator(Generator):
             header += "\n\n.. raw:: html\n\n\t"
             text = text.replace("\n", "\n\t")
 
-            text = hrefs.sub(lambda m: obj._link_replacer(obj.get_siteurl(), m), text)
-
             # rst2pdf casts the text to str and will break if it finds
             # non-escaped characters. Here we nicely escape them to XML/HTML
             # entities before proceeding
@@ -93,6 +85,10 @@ class PdfGenerator(Generator):
             # We don't support this format
             logger.warn("Ignoring unsupported file " + obj.source_path)
             return
+
+        # Find intra-site links and replace placeholder with actual path / url
+        hrefs = self._get_intrasite_link_regex()
+        text = hrefs.sub(lambda m: obj._link_replacer(obj.get_siteurl(), m), text)
 
         logger.info(" [ok] writing %s" % output_pdf)
 

--- a/pelican/plugins/pdf/pdf.py
+++ b/pelican/plugins/pdf/pdf.py
@@ -52,11 +52,13 @@ class PdfGenerator(Generator):
         output_pdf = os.path.join(output_path, filename)
         mdreader = MarkdownReader(self.settings)
         _, ext = os.path.splitext(obj.source_path)
+
+        hrefs = self._get_intrasite_link_regex()
+
         if ext == ".rst":
             with open(obj.source_path, encoding="utf-8") as f:
                 text = f.read()
 
-                hrefs = self._get_intrasite_link_regex()
                 text = hrefs.sub(
                     lambda m: obj._link_replacer(obj.get_siteurl(), m), text
                 )
@@ -80,6 +82,8 @@ class PdfGenerator(Generator):
             header += "\n".join([":{}: {}".format(k, meta[k]) for k in meta])
             header += "\n\n.. raw:: html\n\n\t"
             text = text.replace("\n", "\n\t")
+
+            text = hrefs.sub(lambda m: obj._link_replacer(obj.get_siteurl(), m), text)
 
             # rst2pdf casts the text to str and will break if it finds
             # non-escaped characters. Here we nicely escape them to XML/HTML

--- a/pelican/plugins/pdf/test_data/testfile.md
+++ b/pelican/plugins/pdf/test_data/testfile.md
@@ -8,3 +8,13 @@ Authors: Alexis Metaireau, Conan Doyle
 Summary: Short version for index and feeds
 
 This is the content of my super blog post.
+
+Intra-Site Links:
+
+[a link relative to the current file]({filename}category/article123.rst)
+[a link relative to the content root]({filename}/category/article_123.rst)
+
+[arbitrary case-insensitive reference text]: {filename}category/article456.rst
+[1]: {filename}../category/article789.rst
+
+[link text itself]: {filename}category/article_8-9-0.rst

--- a/pelican/plugins/pdf/test_data/testfile.rst
+++ b/pelican/plugins/pdf/test_data/testfile.rst
@@ -13,16 +13,8 @@ This is the content of my super blog post.
 
 Intra-Site Links:
 
-.. _@testlink: {filename}../article2.md
+.. _@testlink: {filename}testfile_link.rst
 
-`a link relative to the content root <{filename}/article2.md>`_
+`a link relative to the file <{filename}testfile_link.rst>`_
 
-`a link relative to the content root <{filename}/article2.md>`_
-
-.. _@wombelix: {filename}../article2.md
-
-.. _@wombelix: {filename}../article2.md
-
-`a link relative to the content root <{filename}/article2.md>`_
-
-`a link relative to the content root <{filename}/article2.md>`_
+`a second link relative to the file <{filename}testfile_link.rst>`_

--- a/pelican/plugins/pdf/test_data/testfile.rst
+++ b/pelican/plugins/pdf/test_data/testfile.rst
@@ -10,3 +10,19 @@ My super title
 :summary: Short version for index and feeds
 
 This is the content of my super blog post.
+
+Intra-Site Links:
+
+.. _@testlink: {filename}../article2.md
+
+`a link relative to the content root <{filename}/article2.md>`_
+
+`a link relative to the content root <{filename}/article2.md>`_
+
+.. _@wombelix: {filename}../article2.md
+
+.. _@wombelix: {filename}../article2.md
+
+`a link relative to the content root <{filename}/article2.md>`_
+
+`a link relative to the content root <{filename}/article2.md>`_

--- a/pelican/plugins/pdf/test_data/testfile_link.md
+++ b/pelican/plugins/pdf/test_data/testfile_link.md
@@ -1,18 +1,10 @@
-Title: My super title
+Title: My super title - intra-site link target
 Date: 2010-12-03 10:20
 Modified: 2010-12-05 19:30
 Category: Python
 Tags: pelican, publishing
-Slug: my-super-post-md
+Slug: my-super-post-md-link
 Authors: Alexis Metaireau, Conan Doyle
 Summary: Short version for index and feeds
 
 This is the content of my super blog post.
-
-Intra-Site Links:
-
-[a link relative to the current file]({filename}testfile_link.md)
-
-[1]: {filename}testfile_link.md
-
-[link text itself]: {filename}testfile_link.md

--- a/pelican/plugins/pdf/test_data/testfile_link.rst
+++ b/pelican/plugins/pdf/test_data/testfile_link.rst
@@ -1,0 +1,12 @@
+My super title - intra-site link target
+#######################################
+
+:date: 2010-10-03 10:20
+:modified: 2010-10-04 18:40
+:tags: thats, awesome
+:category: yeah
+:slug: my-super-post-rst-link
+:authors: Alexis Metaireau, Conan Doyle
+:summary: Short version for index and feeds
+
+This is the content of my super blog post.

--- a/pelican/plugins/pdf/test_pdf.py
+++ b/pelican/plugins/pdf/test_pdf.py
@@ -29,11 +29,9 @@ class TestPdfGeneration(unittest.TestCase):
         pelican = Pelican(settings=self.settings)
 
         pelican.run()
-        pass
 
     def tearDown(self):
         rmtree(self.temp_path)
-        pass
 
     def test_existence(self):
         assert os.path.exists(

--- a/pelican/plugins/pdf/test_pdf.py
+++ b/pelican/plugins/pdf/test_pdf.py
@@ -1,5 +1,4 @@
 import locale
-import logging
 import os
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -29,15 +28,8 @@ class TestPdfGeneration(unittest.TestCase):
         self.settings = read_settings(override=settings)
         pelican = Pelican(settings=self.settings)
 
-        try:
-            pelican.run()
-        except ValueError:
-            logging.warn(
-                "Relative links in the form of "
-                + "|filename|images/test.png are not yet handled by "
-                + " the pdf generator"
-            )
-            pass
+        pelican.run()
+        pass
 
     def tearDown(self):
         rmtree(self.temp_path)


### PR DESCRIPTION
As stated in the README, the Plugin doesn't support internal linking like:

reStructuredText

```
`a link relative to the current file <{filename}../article2.md>`_
`a link relative to the content root <{filename}/article2.md>`_
```

Markdown

```
[a link relative to the current file]({filename}category/article1.rst)
[a link relative to the content root]({filename}/category/article1.rst)
```

Due to the fact that the PDF Generation is based on the Article / Page Source and not the generated HTML Content, no conversion of the Placeholder like `{filename}` is done prior the Output.

It seems like that implementing a own version of `Content._get_intrasite_link_regex` with adjusted regular expressions and using `Content._link_replacer` could work.

RegEx to detect links in reStructuredText:
```
(?P<markup>)(?P<quote>)(?P<path>(\:?)[{|](?P<what>.*?)[|}](?P<value>.*?)(?=[>\n]))
```

Test Input:
```
.. _@testlink: {filename}../article2.md

`a link relative to the content root <{filename}/article2.md>`_

`a link relative to the content root <{filename}/article2.md>`_

.. _@wombelix: {filename}../article2.md

.. _@wombelix: {filename}../article2.md

`a link relative to the content root <{filename}/article2.md>`_

`a link relative to the content root <{filename}/article2.md>`_

```

@justinmayer maybe you have a moment to let me know if the approach make sense in your opinion. 
Technically it worked quite well in some tests today and produced the expected output, but i'm not that familiar with the Pelican code base yet, there might be a better way implementing this?

The relevant Code:
[pdf.py / R97-R104](https://github.com/pelican-plugins/pdf/compare/main...wombelix:internal_linking?expand=1#diff-f99d6ac7c1601521e4267e0f30ec0d51c29a9d1d4dbedd49f8ae2c9b7792aa81R97-R104)
[pdf.py / R59-62](https://github.com/pelican-plugins/pdf/compare/main...wombelix:internal_linking?expand=1#diff-f99d6ac7c1601521e4267e0f30ec0d51c29a9d1d4dbedd49f8ae2c9b7792aa81R59-R62)