### PR TITLE
Use full path for images to avoid rst2pdf 'Missing image file' error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Use full path for images to avoid rst2pdf “Missing image file” error ([#7](https://github.com/pelican-plugins/pdf/pull/7))

--- a/pelican/plugins/pdf/pdf.py
+++ b/pelican/plugins/pdf/pdf.py
@@ -58,6 +58,11 @@ class PdfGenerator(Generator):
                 text = f.read()
 
             header = ""
+
+            # Use full path for images to avoid rst2pdf 'Missing image file' error
+            # Match reStructuredText Syntax: ..image:: {static}/images/picture.jpg
+            text = re.sub(r"(\.\. image:: )({.*})", r"\1" + self.path, text)
+
         elif ext[1:] in mdreader.file_extensions and mdreader.enabled:
             text, meta = mdreader.read(obj.source_path)
             header = ""
@@ -81,6 +86,11 @@ class PdfGenerator(Generator):
             # non-escaped characters. Here we nicely escape them to XML/HTML
             # entities before proceeding
             text = text.encode("ascii", "xmlcharrefreplace").decode()
+
+            # Use full path for images to avoid rst2pdf 'Missing image file' error
+            # Match Markdown Syntax: ![alt]({static}/images/picture.jpg)
+            text = re.sub(r"(!\[.*\]\()({.*})", r"\1" + self.path, text)
+
         else:
             # We don't support this format
             logger.warn("Ignoring unsupported file " + obj.source_path)


### PR DESCRIPTION
Images added in a Post / Page will not be added to the PDF, rst2pdf can't find the image due to the relative path and will raise a `Missing image file` error. The PDF will be generated, but without the image, a red cross is added instead.

Can be resolved by searching for images and replace `{.*}` (e.g. `{static}`) with the path to Pelican, `~/pelican/content` in the following Example.

before:
`..image:: {static}/images/picture.jpg`

after:
`..image:: ~/pelican/content/images/picture.jpg`

This PR supports reStructuredText and Markdown.