### PR TITLE
refactor: remove xhtml2pdf / rst2pdf workaround

### DIFF
--- a/pelican/plugins/pdf/pdf.py
+++ b/pelican/plugins/pdf/pdf.py
@@ -10,15 +10,11 @@ import logging
 import os
 import re
 
+from rst2pdf.createpdf import RstToPdf
+
 from pelican import signals
 from pelican.generators import Generator
 from pelican.readers import MarkdownReader
-
-# Workaround until fixed xhtml2pdf import is included in rst2pdf Release
-# https://github.com/rst2pdf/rst2pdf/commit/6ad348cf5a13ae1b884a86574e48ed1e5f8ca135
-import xhtml2pdf.default  # NOQA isort:skip
-from rst2pdf.createpdf import RstToPdf  # NOQA isort:skip
-
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = ">=3.8.1,<4.0"
 pelican = ">=4.5"
 markdown = {version = ">=3.2.2", optional = true}
-rst2pdf = ">=0.98"
+rst2pdf = ">=0.99"
 xhtml2pdf = ">=0.2.5"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Workaround not required anymore, fix included in rst2pdf since version 0.99

related https://github.com/rst2pdf/rst2pdf/commit/6ad348cf5a13ae1b884a86574e48ed1e5f8ca135

@justinmayer apologies that I wasn't responsive during the last few months and thanks a lot that you took care about the pull requests for the pdf and touch plugin. I just saw that we can now get rid of a workaround I had to add two years ago.