### PR TITLE
feat: set modified time of generated pdf equal to related article

### DIFF
--- a/pelican/plugins/pdf/pdf.py
+++ b/pelican/plugins/pdf/pdf.py
@@ -9,6 +9,7 @@ from itertools import chain
 import logging
 import os
 import re
+import time
 
 from pelican import signals
 from pelican.generators import Generator
@@ -102,6 +103,9 @@ class PdfGenerator(Generator):
 
         self.pdfcreator.createPdf(text=(header + text), output=output_pdf)
 
+        if obj.date is not None:
+            self._set_file_utime(output_pdf, obj.date)
+
     def _get_intrasite_link_regex(self):
         intrasite_link_regex = self.settings["INTRASITE_LINK_REGEX"]
         regex = r"""
@@ -110,6 +114,11 @@ class PdfGenerator(Generator):
             intrasite_link_regex
         )
         return re.compile(regex, re.X)
+
+    def _set_file_utime(self, path, datetime):
+        """Set modified time (mtime) of specified file."""
+        mtime = time.mktime(datetime.timetuple())
+        os.utime(path, (mtime, mtime))
 
     def generate_context(self):
         pass


### PR DESCRIPTION
@justinmayer PDFs will always re-generated, so far the modified time changed always and was identical as the creation time. With this PR, the modified time will set to `date` from the related article, if set. Result are PDFs with identical size and mtime if the Article wasn't changed, makes it easier to identify and sync real changes.