### PR TITLE
Test PDF generation via GitHub CI action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         run: pdm run invoke tests
 
+      - name: Test generation
+        run: pdm run pelican --fatal errors pelican/plugins/pdf/test_data
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Upstream changes to package dependencies can silently break the plugin, without maintainers knowing, until some hapless user runs into the error and reports it.

It's not clear whether a unit test is appropriate here, so this adds a functional test instead, in the form of an additional step in the `test` CI job.

Refs #17