### PR TITLE
Pin `xhtml2pdf` until import from `rst2pdf` is fixed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+- Test PDF generation via GitHub CI action (#18)
+- Pin `xhtml2pdf` until import from `rst2pdf` is fixed (#19)
+- Replace Poetry with PDM
+- Replace various code style linters with Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.8.1,<4.0"
 dependencies = [
     "pelican>=4.5",
     "rst2pdf>=0.99",
-    "xhtml2pdf>=0.2.5",
+    "xhtml2pdf>=0.2.5,<0.2.12",
 ]
 
 [project.urls]


### PR DESCRIPTION
`xhtml2pdf` [changed the name of a class from `memoized` to `Memoized`](https://github.com/xhtml2pdf/xhtml2pdf/commit/a3211b854672a09e257d8c4cf7192e30a2690d58#diff-a3bbad1de17b7fa3acba9bbdf547b6e0b3c4a88a75b7b74ce193056cfc7a8317R44) and released that change in [v0.2.12](https://github.com/xhtml2pdf/xhtml2pdf/releases/tag/v0.2.12).

[`rst2pdf` still tries to import it with the old lower-case name](https://github.com/rst2pdf/rst2pdf/blob/44b5e1de4bb4e46524ca48202cab25f3157fcc28/rst2pdf/utils.py#L88), which causes the import to fail, which causes PDF generation fail. This pin can probably be removed once `rst2pdf` fixes that import.

Fixes #17